### PR TITLE
MPI Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ env:
         # List runtime dependencies for the package that are available as conda
         # packages here.
         - CONDA_DEPENDENCIES='configobj healpy'
+        - CONDA_DEPENDENCIES_MPI='configobj healpy mpi4py'
         - CONDA_DEPENDENCIES_DOC='configobj healpy sphinx-astropy'
         
         # List other runtime dependencies for the package that are available as
@@ -103,6 +104,11 @@ matrix:
           env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.13
         - os: linux
           env: NUMPY_VERSION=1.14
+
+        - os: linux
+          env: NUMPY_VERSION=1.14
+               MAIN_CMD='bash run_mpi_tests.sh'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_MPI
 
         # Try numpy pre-release
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ env:
         # List runtime dependencies for the package that are available as conda
         # packages here.
         - CONDA_DEPENDENCIES='configobj healpy'
-        - CONDA_DEPENDENCIES_MPI='configobj healpy mpi4py'
+        - CONDA_DEPENDENCIES_MPI='configobj healpy openmpi'
         - CONDA_DEPENDENCIES_DOC='configobj healpy sphinx-astropy'
         
         # List other runtime dependencies for the package that are available as
@@ -109,6 +109,7 @@ matrix:
           env: NUMPY_VERSION=1.14
                MAIN_CMD='bash ci/install_libsharp.sh && bash run_mpi_tests.sh'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_MPI
+               PIP_DEPENDENCIES='mpi4py'
 
         # Try numpy pre-release
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ matrix:
 
         - os: linux
           env: NUMPY_VERSION=1.14
-               MAIN_CMD='bash run_mpi_tests.sh'
+               MAIN_CMD='bash ci/install_libsharp.sh && bash run_mpi_tests.sh'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_MPI
 
         # Try numpy pre-release

--- a/ci/install_libsharp.sh
+++ b/ci/install_libsharp.sh
@@ -1,0 +1,11 @@
+export LIBSHARP=~/miniconda
+git clone https://github.com/Libsharp/libsharp --branch v1.0.0 --single-branch --depth 1 \
+    && cd libsharp \
+    && autoreconf \
+    && CC="mpicc" \
+    ./configure --enable-mpi --enable-pic \
+    && make \
+    && cp -a auto/* $LIBSHARP \
+    && cd python \
+    && CC="mpicc -g" LDSHARED="mpicc -g -shared" \
+    pip install .

--- a/pysm/component_models/galactic/synchrotron.py
+++ b/pysm/component_models/galactic/synchrotron.py
@@ -1,6 +1,6 @@
 import numpy as np
 import astropy.units as units
-from ..template import Model, check_freq_input, read_map
+from ..template import Model, check_freq_input
 
 class SynchrotronPowerLaw(Model):
     """ This is a model for a simple power law synchrotron model.
@@ -26,15 +26,14 @@ class SynchrotronPowerLaw(Model):
         nside: int
             Resolution parameter at which this model is to be calculated.
         """
-        Model.__init__(self, mpi_comm)
+        Model.__init__(self, mpi_comm, nside)
         # do model setup
-        self.I_ref = read_map(map_I, nside)[None, :] * units.uK
-        self.Q_ref = read_map(map_Q, nside)[None, :] * units.uK
-        self.U_ref = read_map(map_U, nside)[None, :] * units.uK
+        self.I_ref = self.read_map(map_I)[None, :] * units.uK
+        self.Q_ref = self.read_map(map_Q)[None, :] * units.uK
+        self.U_ref = self.read_map(map_U)[None, :] * units.uK
         self.freq_ref_I = freq_ref_I * units.GHz
         self.freq_ref_P = freq_ref_P * units.GHz
-        self.pl_index = read_map(map_pl_index, nside)[None, :]
-        self.nside = nside
+        self.pl_index = self.read_map(map_pl_index)[None, :]
         return
 
     def get_emission(self, freqs):

--- a/pysm/component_models/galactic/synchrotron.py
+++ b/pysm/component_models/galactic/synchrotron.py
@@ -2,11 +2,23 @@ import numpy as np
 import astropy.units as units
 from ..template import Model, check_freq_input
 
+
 class SynchrotronPowerLaw(Model):
     """ This is a model for a simple power law synchrotron model.
     """
-    def __init__(self, map_I=None, map_Q=None, map_U=None, freq_ref_I=None,
-                 freq_ref_P=None, map_pl_index=None, nside=None, mpi_comm=None):
+
+    def __init__(
+        self,
+        map_I,
+        map_Q,
+        map_U,
+        freq_ref_I,
+        freq_ref_P,
+        map_pl_index,
+        nside,
+        pixel_indices=None,
+        mpi_comm=None,
+    ):
         """ This function initialzes the power law model of synchrotron
         emission.
 
@@ -26,7 +38,7 @@ class SynchrotronPowerLaw(Model):
         nside: int
             Resolution parameter at which this model is to be calculated.
         """
-        Model.__init__(self, mpi_comm, nside)
+        super().__init__(nside, pixel_indices=pixel_indices, mpi_comm=mpi_comm)
         # do model setup
         self.I_ref = self.read_map(map_I)[None, :] * units.uK
         self.Q_ref = self.read_map(map_Q)[None, :] * units.uK
@@ -58,8 +70,8 @@ class SynchrotronPowerLaw(Model):
         for freq in freqs:
             I_scal = (freq / self.freq_ref_I) ** self.pl_index
             P_scal = (freq / self.freq_ref_P) ** self.pl_index
-            iqu_freq = np.concatenate((I_scal * self.I_ref,
-                                       P_scal * self.Q_ref,
-                                       P_scal * self.U_ref))
+            iqu_freq = np.concatenate(
+                (I_scal * self.I_ref, P_scal * self.Q_ref, P_scal * self.U_ref)
+            )
             outputs.append(iqu_freq)
         return np.array(outputs)

--- a/pysm/component_models/template.py
+++ b/pysm/component_models/template.py
@@ -252,17 +252,6 @@ def read_map(
         mpi_comm.Bcast(output_map, root=0)
         unit_string = mpi_comm.bcast(unit_string, root=0)
 
-    if mpi_comm is not None and pixel_indices is None:
-        if distribute_rings_libsharp:
-            pass
-        else:
-            npix = hp.nside2npix(nside)
-            pix_per_proc = int(np.ceil(npix / mpi_comm.size))
-            pixel_indices = np.arange(
-                mpi_comm.rank * pix_per_proc,
-                min((mpi_comm.rank + 1) * pix_per_proc, npix),
-            )
-
     if pixel_indices is not None:
         try:  # multiple components
             output_map = np.array([each[pixel_indices] for each in output_map])

--- a/pysm/component_models/template.py
+++ b/pysm/component_models/template.py
@@ -240,6 +240,7 @@ def read_map(path, nside, field=0, pixel_indices=None, mpi_comm=None):
             ncomp = 1
         shape = npix if ncomp == 1 else (len(field), npix)
         output_map = np.empty(shape, dtype=np.float64)
+        unit_string = ""
 
     if mpi_comm is not None:
         mpi_comm.Bcast(output_map, root=0)

--- a/pysm/mpi.py
+++ b/pysm/mpi.py
@@ -29,3 +29,68 @@ def distribute_pixels_uniformly(mpi_comm, nside):
     )
     return pixel_indices
 
+def expand_pix(startpix, ringpix, local_npix):
+    """Turn first pixel index and number of pixel in full array of pixels
+    to be optimized with cython
+    """
+    i = 0
+    local_pix = np.zeros(local_npix)
+    for start, num in zip(startpix, ringpix):
+        local_pix[i:i + num] = np.arange(start, start + num)
+        i += num
+    return local_pix
+
+
+def distribute_rings_libsharp(mpi_comm, nside):
+    """Create a libsharp map distribution based on rings
+
+    Build a libsharp grid object to distribute a HEALPix map
+    balancing North and South distribution of rings to achieve
+    the best performance on Harmonic Transforms
+    Returns the grid object and the pixel indices array in RING ordering
+
+    Parameters
+    ---------
+    mpi_comm : mpi4py.MPI.Comm
+        mpi4py communicator
+    nside : int
+        nside of the map
+
+    Returns
+    -------
+    grid : libsharp.healpix_grid
+        libsharp object that includes metadata about HEALPix distributed rings
+    local_pix : np.ndarray
+        integer array of local pixel indices in the current MPI process in RING
+        ordering
+    """
+    nrings = 4 * nside - 1  # four missing pixels
+
+    # ring indices are 1-based
+    ring_indices_emisphere = np.arange(2 * nside, dtype=np.int32) + 1
+
+    local_ring_indices = ring_indices_emisphere[mpi_comm.rank::mpi_comm.size]
+
+    # to improve performance, symmetric rings north/south need to be in the same rank
+    # therefore we use symmetry to create the full ring indexing
+
+    if local_ring_indices[-1] == 2 * nside:
+        # has equator ring
+        local_ring_indices = np.concatenate(
+            [local_ring_indices[:-1], nrings - local_ring_indices[::-1] + 1]
+        )
+    else:
+        # does not have equator ring
+        local_ring_indices = np.concatenate(
+            [local_ring_indices, nrings - local_ring_indices[::-1] + 1]
+        )
+
+    libsharp_grid = libsharp.healpix_grid(nside, rings=local_ring_indices)
+
+    # returns start index of the ring and number of pixels
+    startpix, ringpix, _, _, _ = hp.ringinfo(
+        nside, local_ring_indices.astype(np.int64))
+
+    local_npix = libsharp_grid.local_size()
+    local_pixels = expand_pix(startpix, ringpix, local_npix)
+    return local_pixels, libsharp_grid

--- a/pysm/mpi.py
+++ b/pysm/mpi.py
@@ -1,0 +1,31 @@
+import healpy as hp
+import numpy as np
+
+try:
+    import libsharp
+except ImportError:
+    libsharp = None
+
+def distribute_pixels_uniformly(mpi_comm, nside):
+    """Define the pixel_indices for each MPI rank to distribute a map uniformly
+
+    Parameters
+    ----------
+    mpi_comm : mpi4py.MPI.Comm
+        mpi4py communicator
+    nside : int
+        nside of the map
+
+    Returns
+    -------
+    pixel_indices : np.ndarray
+        local pixel indices
+    """
+    npix = hp.nside2npix(nside)
+    pix_per_proc = int(np.ceil(npix / mpi_comm.size))
+    pixel_indices = np.arange(
+        mpi_comm.rank * pix_per_proc,
+        min((mpi_comm.rank + 1) * pix_per_proc, npix),
+    )
+    return pixel_indices
+

--- a/pysm/tests/test_read_map_mpi.py
+++ b/pysm/tests/test_read_map_mpi.py
@@ -1,0 +1,29 @@
+import pytest
+import pysm
+
+try:
+    from mpi4py import MPI
+except ImportError:
+    pytest.skip("mpi4py failed to import, skip MPI tests", allow_module_level=True)
+
+
+@pytest.fixture
+def setup_mpi_communicator():
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    return comm, rank
+
+
+def test_read_map_mpi(setup_mpi_communicator):
+    comm, rank = setup_mpi_communicator
+    # Reads pixel [0] on rank 0
+    # pixels [0,1] on rank 1
+    # pixels [0,1,2] on rank 2 and so on.
+    m = pysm.read_map(
+        "pysm_2/dust_temp.fits",
+        nside=8,
+        field=0,
+        pixel_indices=list(range(0, rank + 1)),
+        mpi_comm=comm,
+    )
+    assert len(m) == rank + 1

--- a/pysm/tests/test_read_map_mpi.py
+++ b/pysm/tests/test_read_map_mpi.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 import healpy as hp
 import pysm
 
@@ -9,14 +10,12 @@ except ImportError:
 
 
 @pytest.fixture
-def setup_mpi_communicator():
+def mpi_comm():
     comm = MPI.COMM_WORLD
-    rank = comm.Get_rank()
-    return comm, rank
+    return comm
 
 
-def test_read_map_mpi_pixel_indices(setup_mpi_communicator):
-    comm, rank = setup_mpi_communicator
+def test_read_map_mpi_pixel_indices(mpi_comm):
     # Reads pixel [0] on rank 0
     # pixels [0,1] on rank 1
     # pixels [0,1,2] on rank 2 and so on.
@@ -24,27 +23,43 @@ def test_read_map_mpi_pixel_indices(setup_mpi_communicator):
         "pysm_2/dust_temp.fits",
         nside=8,
         field=0,
-        pixel_indices=list(range(0, rank + 1)),
-        mpi_comm=comm,
+        pixel_indices=list(range(0, mpi_comm.rank + 1)),
+        mpi_comm=mpi_comm,
     )
-    assert len(m) == rank + 1
+    assert len(m) == mpi_comm.rank + 1
 
 
-def test_read_map_mpi_uniform_distribution(setup_mpi_communicator):
-    comm, rank = setup_mpi_communicator
+def test_read_map_mpi_uniform_distribution(mpi_comm):
     # Spreads the map equally across processes
-    pixel_indices = pysm.mpi.distribute_pixels_uniformly(comm, nside=8)
+    pixel_indices = pysm.mpi.distribute_pixels_uniformly(mpi_comm, nside=8)
     m = pysm.read_map(
         "pysm_2/dust_temp.fits",
         nside=8,
         field=0,
         pixel_indices=pixel_indices,
-        mpi_comm=comm,
+        mpi_comm=mpi_comm,
     )
     npix = hp.nside2npix(8)
     assert (
-        npix % comm.size == 0
+        npix % mpi_comm.size == 0
     ), "This test requires the size of the communicator to divide the number of pixels {}".format(
         npix
     )
-    assert len(m) == npix / comm.size
+    assert len(m) == npix / mpi_comm.size
+
+
+def test_distribute_rings_libsharp(mpi_comm):
+    nside = 1
+    two_processes_comm = mpi_comm.Split(
+        color=0 if mpi_comm.rank in [0, 1] else MPI.UNDEFINED, key=mpi_comm.rank
+    )
+    if mpi_comm.rank in [0, 1]:
+        local_pixels, grid = pysm.mpi.distribute_rings_libsharp(
+            two_processes_comm, nside
+        )
+        expected_local_pixels = (
+            np.concatenate([np.arange(4), np.arange(8, 12)])
+            if mpi_comm.rank == 0
+            else np.arange(4, 8)
+        )
+        np.testing.assert_allclose(local_pixels, expected_local_pixels)

--- a/pysm/tests/test_read_map_mpi.py
+++ b/pysm/tests/test_read_map_mpi.py
@@ -33,14 +33,18 @@ def test_read_map_mpi_pixel_indices(setup_mpi_communicator):
 def test_read_map_mpi_uniform_distribution(setup_mpi_communicator):
     comm, rank = setup_mpi_communicator
     # Spreads the map equally across processes
+    pixel_indices = pysm.mpi.distribute_pixels_uniformly(comm, nside=8)
     m = pysm.read_map(
         "pysm_2/dust_temp.fits",
         nside=8,
         field=0,
-        pixel_indices=None,
+        pixel_indices=pixel_indices,
         mpi_comm=comm,
-        distribute_rings_libsharp=False
     )
     npix = hp.nside2npix(8)
-    assert npix % comm.size == 0, "This test requires the size of the communicator to divide the number of pixels {}".format(npix)
-    assert len(m) == npix/comm.size
+    assert (
+        npix % comm.size == 0
+    ), "This test requires the size of the communicator to divide the number of pixels {}".format(
+        npix
+    )
+    assert len(m) == npix / comm.size

--- a/run_mpi_tests.sh
+++ b/run_mpi_tests.sh
@@ -1,0 +1,1 @@
+mpirun -np 2 python setup.py test -V -t pysm/tests/test_read_map_mpi.py


### PR DESCRIPTION
Started working on MPI support.

Having a `Model.read_map` method instead of a `read_map` function makes it easy to access `self.nside`, `self.mpi_comm` and `self.pixel_indices` without passing those around everywhere like in PySM 2.

Next:

* [x] consistently use the new `self.read_map` everywhere and make sure serial unit tests pass
* [x] implement the data distribution for the MPI case based on the TOAST PySM operator
* [ ] implement distributed smoothing with libsharp, also based on the TOAST PySM operator
* [x] implement testing for the partial map functionality
* [x] implement testing for MPI support
