### PR TITLE
Implementation of MPI smoothing based on libsharp

### DIFF
--- a/pysm/tests/test_mpi_smoothing.py
+++ b/pysm/tests/test_mpi_smoothing.py
@@ -1,0 +1,45 @@
+import pytest
+import numpy as np
+import healpy as hp
+import pysm
+import astropy.units as u
+
+try:
+    from mpi4py import MPI
+except ImportError:
+    pytest.skip("mpi4py failed to import, skip MPI tests", allow_module_level=True)
+
+
+@pytest.fixture
+def mpi_comm():
+    comm = MPI.COMM_WORLD
+    return comm
+
+
+def test_mpi_smoothing(mpi_comm):
+    nside = 256
+    lmax = 2 * nside
+    model = pysm.Model(
+        nside, mpi_comm=mpi_comm, pixel_indices=None, smoothing_lmax=lmax
+    )
+    distributed_map = model.read_map("pysm_2/dust_temp.fits")
+    fwhm = 5 * u.deg
+    smoothed_distributed_map = model.mpi_smoothing(distributed_map, fwhm)
+    full_map_rank0 = pysm.mpi.assemble_map_on_rank0(
+        mpi_comm,
+        smoothed_distributed_map,
+        model.pixel_indices,
+        n_components=1,
+        npix=hp.nside2npix(nside),
+    )[0]
+    if mpi_comm.rank == 0:
+        np.testing.assert_allclose(
+            full_map_rank0,
+            hp.smoothing(
+                pysm.read_map("pysm_2/dust_temp.fits", nside=nside).value,
+                fwhm.to(u.rad).value,
+                lmax=lmax,
+                use_pixel_weights=True,
+            ),
+            rtol=1e-3,
+        )

--- a/pysm/tests/test_mpi_smoothing.py
+++ b/pysm/tests/test_mpi_smoothing.py
@@ -17,7 +17,7 @@ def mpi_comm():
 
 
 def test_mpi_smoothing(mpi_comm):
-    nside = 256
+    nside = 128
     lmax = 2 * nside
     model = pysm.Model(
         nside, mpi_comm=mpi_comm, pixel_indices=None, smoothing_lmax=lmax
@@ -38,8 +38,9 @@ def test_mpi_smoothing(mpi_comm):
             hp.smoothing(
                 pysm.read_map("pysm_2/dust_temp.fits", nside=nside).value,
                 fwhm.to(u.rad).value,
+                iter=0,
                 lmax=lmax,
-                use_pixel_weights=True,
+                use_pixel_weights=False,
             ),
-            rtol=1e-3,
+            rtol=1e-5,
         )

--- a/pysm/tests/test_mpi_smoothing.py
+++ b/pysm/tests/test_mpi_smoothing.py
@@ -9,6 +9,11 @@ try:
 except ImportError:
     pytest.skip("mpi4py failed to import, skip MPI tests", allow_module_level=True)
 
+try:
+    import libsharp
+except ImportError:
+    pytest.skip("libsharp failed to import, skip MPI smoothing tests", allow_module_level=True)
+
 
 @pytest.fixture
 def mpi_comm():

--- a/pysm/tests/test_read_map_mpi.py
+++ b/pysm/tests/test_read_map_mpi.py
@@ -49,18 +49,22 @@ def test_read_map_mpi_uniform_distribution(mpi_comm):
 
 
 def test_distribute_rings_libsharp(mpi_comm):
-    pytest.importorskip("libsharp") # execute only if libsharp is available
+    pytest.importorskip("libsharp")  # execute only if libsharp is available
     nside = 1
     two_processes_comm = mpi_comm.Split(
         color=0 if mpi_comm.rank in [0, 1] else MPI.UNDEFINED, key=mpi_comm.rank
     )
     if mpi_comm.rank in [0, 1]:
-        local_pixels, grid = pysm.mpi.distribute_rings_libsharp(
-            two_processes_comm, nside
+        local_pixels, grid, order = pysm.mpi.distribute_rings_libsharp(
+            two_processes_comm, nside, lmax=2 * nside
         )
-        expected_local_pixels = (
-            np.concatenate([np.arange(4), np.arange(8, 12)])
-            if mpi_comm.rank == 0
-            else np.arange(4, 8)
-        )
+
+        if mpi_comm.size == 1: # serial
+            expected_local_pixels = np.arange(12)
+        else:
+            expected_local_pixels = (
+                np.concatenate([np.arange(4), np.arange(8, 12)])
+                if mpi_comm.rank == 0
+                else np.arange(4, 8)
+            )
         np.testing.assert_allclose(local_pixels, expected_local_pixels)

--- a/pysm/tests/test_utils.py
+++ b/pysm/tests/test_utils.py
@@ -1,0 +1,14 @@
+import numpy as np
+import pysm
+
+def test_has_polarization():
+    h = pysm.utils.has_polarization
+
+    m = np.empty(12)
+    assert h(np.empty((3, 12)))
+    assert not h(np.empty((1, 12)))
+    assert not h(m)
+    assert h(np.empty((4, 3, 12)))
+    assert not h(np.empty((4, 1, 12)))
+    assert h((m, m, m))
+    assert h([(m, m, m), (m, m, m)])

--- a/pysm/utils/__init__.py
+++ b/pysm/utils/__init__.py
@@ -2,3 +2,22 @@
 
 # This sub-module is destined for common non-package specific utility
 # functions.
+
+import numpy as np
+
+def has_polarization(m):
+    """Checks if a map or a group of map is polarized
+
+    Works with a map of shape (IQU, npix) or
+    (channels, IQU, npix)"""
+    if isinstance(m, np.ndarray): # array
+        if m.ndim == 1:
+            return False
+        else:
+            return m.shape[-2] == 3
+    elif isinstance(m[0], np.ndarray): # IQU tuple
+        return len(m) == 3
+    elif isinstance(m[0][0], np.ndarray): # multiple IQU tuples
+        return len(m[0]) == 3
+    else:
+        raise TypeError("Map format not understood")


### PR DESCRIPTION
Implementation is complete and test passes,

I had to set `iter=0` and use no weights to get the same result with `hp.smoothing` as I get in `libsharp`, asked on the `libsharp` repo:

https://github.com/Libsharp/libsharp/issues/19