### PR TITLE
Bandpass integration and MPI debugging

### DIFF
--- a/mpi_examples/pysm3_mpi.py
+++ b/mpi_examples/pysm3_mpi.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pysm
+import pysm.units as u
+
+from mpi4py import MPI
+
+nside = 32
+
+map_dist = pysm.MapDistribution(
+    pixel_indices=None, nside=nside, mpi_comm=MPI.COMM_WORLD
+)
+
+sky = pysm.Sky(nside=nside, preset_strings=["d1", "s1", "f1", "a1"], map_dist=map_dist)
+
+m = sky.get_emission(
+    freq=np.arange(50, 55) * u.GHz, weights=np.array([0.1, 0.3, 0.5, 0.3, 0.1])
+)[0]
+
+print(map_dist.mpi_comm.rank, m.shape, m.min(), m.max())
+
+m_smoothed = pysm.apply_smoothing_and_coord_transform(
+    m, fwhm=1 * u.deg, map_dist=map_dist
+)
+
+print(map_dist.mpi_comm.rank, m_smoothed.shape, m_smoothed.min(), m_smoothed.max())

--- a/mpi_examples/pysm3_mpi_so_pysm_models.py
+++ b/mpi_examples/pysm3_mpi_so_pysm_models.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pysm
+import pysm.units as u
+from so_pysm_models import get_so_models
+
+from mpi4py import MPI
+
+nside = 32
+
+map_dist = pysm.MapDistribution(
+    pixel_indices=None, nside=nside, mpi_comm=MPI.COMM_WORLD
+)
+
+components = []
+for comp in ["SO_d0", "SO_s0", "SO_f0", "SO_a0"]:
+    components.append(get_so_models(comp, nside, map_dist=map_dist))
+
+sky = pysm.Sky(nside=nside, component_objects=components, map_dist=map_dist)
+
+m = sky.get_emission(
+    freq=np.arange(50, 55) * u.GHz, weights=np.array([0.1, 0.3, 0.5, 0.3, 0.1])
+)[0]
+
+print(map_dist.mpi_comm.rank, m.shape, m.min(), m.max())
+
+m_smoothed = pysm.apply_smoothing_and_coord_transform(
+    m, fwhm=1 * u.deg, map_dist=map_dist
+)
+
+print(map_dist.mpi_comm.rank, m_smoothed.shape, m_smoothed.min(), m_smoothed.max())

--- a/mpi_examples/pysm3_mpi_so_pysm_models.py
+++ b/mpi_examples/pysm3_mpi_so_pysm_models.py
@@ -2,6 +2,7 @@ import numpy as np
 import pysm
 import pysm.units as u
 from so_pysm_models import get_so_models
+import so_pysm_models
 
 from mpi4py import MPI
 
@@ -14,6 +15,12 @@ map_dist = pysm.MapDistribution(
 components = []
 for comp in ["SO_d0", "SO_s0", "SO_f0", "SO_a0"]:
     components.append(get_so_models(comp, nside, map_dist=map_dist))
+
+components.append(so_pysm_models.WebSkyCIB(
+  websky_version = "0.3",
+  interpolation_kind = "linear",
+  target_nside = nside,
+  map_dist = map_dist))
 
 sky = pysm.Sky(nside=nside, component_objects=components, map_dist=map_dist)
 

--- a/pysm/__init__.py
+++ b/pysm/__init__.py
@@ -32,3 +32,4 @@ if not _ASTROPY_SETUP_:
 from .models import *
 from .sky import Sky
 from . import units
+from .distribution import MapDistribution

--- a/pysm/distribution.py
+++ b/pysm/distribution.py
@@ -1,0 +1,47 @@
+from . import mpi
+
+
+class MapDistribution:
+    def __init__(
+        self, pixel_indices=None, mpi_comm=None, nside=None, smoothing_lmax=None
+    ):
+        """Define how a map is distributed
+
+        In a serial environment, this is only useful if you want to generate a partial sky,
+        pass an array `pixel_indices` with the indices in RING ordering.
+
+        in a MPI environment, pass a `mpi4py` communicator and the desired :math:`\ell_{max}`
+        for smoothing and this class will create a ring-based distribution suitable for smoothing
+        with `libsharp`.
+
+        Parameters
+        ----------
+        pixel_indices : ndarray of integers
+            Subset of pixels that should be used in RING ordering
+        mpi_comm: object
+            MPI communicator object (optional, default=None).
+        nside: int
+            Resolution parameter at which this model is to be calculated.
+        smoothing_lmax : int
+            :math:`\ell_{max}` for the smoothing step, by default :math:`3*N_{side}-1`
+        """
+        self.pixel_indices = pixel_indices
+        self.mpi_comm = mpi_comm
+        self.smoothing_lmax = smoothing_lmax
+        self.nside = nside
+
+        if self.mpi_comm is not None and pixel_indices is None:
+            assert (
+                self.nside is not None
+            ), "libsharp needs to know the NSIDE to create the distribution"
+            if self.smoothing_lmax is None:
+                self.smoothing_lmax = 3 * self.nside - 1
+
+            if mpi.libsharp is None:
+                self.pixel_indices = mpi.distribute_pixels_uniformly(
+                    self.mpi_comm, self.nside
+                )
+            else:
+                self.pixel_indices, self.libsharp_grid, self.libsharp_order = mpi.distribute_rings_libsharp(
+                    self.mpi_comm, self.nside, lmax=self.smoothing_lmax
+                )

--- a/pysm/models/__init__.py
+++ b/pysm/models/__init__.py
@@ -1,5 +1,10 @@
 from .dust import ModifiedBlackBody, DecorrelatedModifiedBlackBody
 from .power_law import PowerLaw
-from .template import Model, read_map, apply_smoothing, mpi_smoothing
+from .template import (
+    Model,
+    read_map,
+    apply_smoothing_and_coord_transform,
+    mpi_smoothing,
+)
 from .spdust import SpDust, SpDustPol
 from .interpolating import InterpolatingComponent

--- a/pysm/models/__init__.py
+++ b/pysm/models/__init__.py
@@ -5,6 +5,7 @@ from .template import (
     read_map,
     apply_smoothing_and_coord_transform,
     mpi_smoothing,
+    check_freq_input,
 )
 from .spdust import SpDust, SpDustPol
 from .interpolating import InterpolatingComponent

--- a/pysm/models/dust.py
+++ b/pysm/models/dust.py
@@ -145,7 +145,7 @@ def get_emission_numba(
         temp = output
 
     I, Q, U = 0, 1, 2
-    for freq, weight in zip(freqs, weights):
+    for i, (freq, weight) in enumerate(zip(freqs, weights)):
         temp[I, :] = I_ref
         temp[Q, :] = Q_ref
         temp[U, :] = U_ref
@@ -154,8 +154,9 @@ def get_emission_numba(
         temp[I] *= blackbody_ratio(freq, freq_ref_I, mbb_temperature)
         temp[Q:] *= blackbody_ratio(freq, freq_ref_P, mbb_temperature)
         if len(freqs) > 1:
-            output += temp * weight
+            utils.trapz_step_inplace(freqs, weights, i, temp, output)
     return output
+
 
 
 class DecorrelatedModifiedBlackBody(ModifiedBlackBody):

--- a/pysm/models/dust.py
+++ b/pysm/models/dust.py
@@ -3,6 +3,7 @@ import warnings
 from .. import units as u
 from pathlib import Path
 from .template import Model, check_freq_input
+from .. import utils
 
 from numba import njit
 from astropy import constants as const
@@ -33,8 +34,7 @@ class ModifiedBlackBody(Model):
         unit_Q=None,
         unit_U=None,
         unit_mbb_temperature=None,
-        pixel_indices=None,
-        mpi_comm=None,
+        map_dist=None,
     ):
         """ This function initializes the modified black body model.
 
@@ -64,7 +64,7 @@ class ModifiedBlackBody(Model):
         nside: int
             Resolution parameter at which this model is to be calculated.
         """
-        super().__init__(nside=nside, pixel_indices=pixel_indices, mpi_comm=mpi_comm)
+        super().__init__(nside=nside, map_dist=map_dist)
         # do model setup
         self.I_ref = self.read_map(map_I, unit=unit_I)
         # This does unit conversion in place so we do not copy the data
@@ -79,15 +79,21 @@ class ModifiedBlackBody(Model):
             self.U_ref = self.read_map(map_U, unit=unit_U)
             self.U_ref <<= u.uK_RJ
             self.freq_ref_P = u.Quantity(freq_ref_P).to(u.GHz)
-        self.mbb_index = self.read_map(map_mbb_index, unit="") if isinstance(map_mbb_index, (str, Path)) else u.Quantity(map_mbb_index, unit="")
-        self.mbb_temperature = self.read_map(
-            map_mbb_temperature, unit=unit_mbb_temperature
-        ) if isinstance(map_mbb_index, (str, Path)) else map_mbb_temperature
+        self.mbb_index = (
+            self.read_map(map_mbb_index, unit="")
+            if isinstance(map_mbb_index, (str, Path))
+            else u.Quantity(map_mbb_index, unit="")
+        )
+        self.mbb_temperature = (
+            self.read_map(map_mbb_temperature, unit=unit_mbb_temperature)
+            if isinstance(map_mbb_index, (str, Path))
+            else map_mbb_temperature
+        )
         self.mbb_temperature <<= u.K
         self.nside = int(nside)
 
     @u.quantity_input
-    def get_emission(self, freqs: u.GHz) -> u.uK_RJ:
+    def get_emission(self, freqs: u.GHz, weights=None) -> u.uK_RJ:
         """ This function evaluates the component model at a either
         a single frequency, an array of frequencies, or over a bandpass.
 
@@ -105,8 +111,10 @@ class ModifiedBlackBody(Model):
         """
         # freqs must be given in GHz.
         freqs = check_freq_input(freqs)
+        weights = utils.normalize_weights(freqs, weights)
         outputs = get_emission_numba(
             freqs.value,
+            weights,
             self.I_ref.value,
             self.Q_ref.value,
             self.U_ref.value,
@@ -120,19 +128,34 @@ class ModifiedBlackBody(Model):
 
 @njit(parallel=True)
 def get_emission_numba(
-    freqs, I_ref, Q_ref, U_ref, freq_ref_I, freq_ref_P, mbb_index, mbb_temperature
+    freqs,
+    weights,
+    I_ref,
+    Q_ref,
+    U_ref,
+    freq_ref_I,
+    freq_ref_P,
+    mbb_index,
+    mbb_temperature,
 ):
-    outputs = np.empty((len(freqs), 3, len(I_ref)), dtype=I_ref.dtype)
+    output = np.zeros((3, len(I_ref)), dtype=I_ref.dtype)
+    if len(freqs) > 1:
+        temp = np.zeros((3, len(I_ref)), dtype=I_ref.dtype)
+    else:
+        temp = output
+
     I, Q, U = 0, 1, 2
-    for i_freq, freq in enumerate(freqs):
-        outputs[i_freq, I, :] = I_ref
-        outputs[i_freq, Q, :] = Q_ref
-        outputs[i_freq, U, :] = U_ref
-        outputs[i_freq, I] *= (freq / freq_ref_I) ** (mbb_index - 2.0)
-        outputs[i_freq, Q:] *= (freq / freq_ref_P) ** (mbb_index - 2.0)
-        outputs[i_freq, I] *= blackbody_ratio(freq, freq_ref_I, mbb_temperature)
-        outputs[i_freq, Q:] *= blackbody_ratio(freq, freq_ref_P, mbb_temperature)
-    return outputs
+    for freq, weight in zip(freqs, weights):
+        temp[I, :] = I_ref
+        temp[Q, :] = Q_ref
+        temp[U, :] = U_ref
+        temp[I] *= (freq / freq_ref_I) ** (mbb_index - 2.0)
+        temp[Q:] *= (freq / freq_ref_P) ** (mbb_index - 2.0)
+        temp[I] *= blackbody_ratio(freq, freq_ref_I, mbb_temperature)
+        temp[Q:] *= blackbody_ratio(freq, freq_ref_P, mbb_temperature)
+        if len(freqs) > 1:
+            output += temp * weight
+    return output
 
 
 class DecorrelatedModifiedBlackBody(ModifiedBlackBody):

--- a/pysm/models/power_law.py
+++ b/pysm/models/power_law.py
@@ -125,10 +125,12 @@ def get_emission_numba_IQU(
     has_pol = Q_ref is not None
     output = np.zeros((3, len(I_ref)), dtype=I_ref.dtype)
     I, Q, U = 0, 1, 2
-    for freq, weight in zip(freqs, weights):
-        output[I] += weight * I_ref * (freq / freq_ref_I) ** pl_index
+    for i, (freq, weight) in enumerate(zip(freqs, weights)):
+        utils.trapz_step_inplace(
+            freqs, weights, i, I_ref * (freq / freq_ref_I) ** pl_index, output[I]
+        )
         if has_pol:
-            pol_scaling = (freq / freq_ref_P) ** pl_index * weight
-            output[Q] += Q_ref * pol_scaling
-            output[U] += U_ref * pol_scaling
+            pol_scaling = (freq / freq_ref_P) ** pl_index
+            utils.trapz_step_inplace(freqs, weights, i, Q_ref * pol_scaling, output[Q])
+            utils.trapz_step_inplace(freqs, weights, i, U_ref * pol_scaling, output[U])
     return output

--- a/pysm/models/spdust.py
+++ b/pysm/models/spdust.py
@@ -1,6 +1,7 @@
 import numpy as np
 from .. import units as u
 from numba import njit
+from .. import utils
 
 from .template import Model, check_freq_input
 
@@ -22,8 +23,7 @@ class SpDust(Model):
         freq_ref_peak,
         nside,
         unit_I=None,
-        pixel_indices=None,
-        mpi_comm=None,
+        map_dist=None,
     ):
         """ This function initializes the spinning dust model
 
@@ -48,7 +48,7 @@ class SpDust(Model):
         nside: int
             Resolution parameter at which this model is to be calculated.
         """
-        super().__init__(nside=nside, pixel_indices=pixel_indices, mpi_comm=mpi_comm)
+        super().__init__(nside=nside, map_dist=map_dist)
         # do model setup
         self.I_ref = self.read_map(map_I, unit=unit_I)
         # This does unit conversion in place so we do not copy the data
@@ -65,7 +65,7 @@ class SpDust(Model):
         self.emissivity = self.read_txt(emissivity, unpack=True)
 
     @u.quantity_input
-    def get_emission(self, freqs: u.GHz):
+    def get_emission(self, freqs: u.GHz, weights=None):
         """ This function evaluates the component model at a either
         a single frequency, an array of frequencies, or over a bandpass.
 
@@ -82,9 +82,11 @@ class SpDust(Model):
             shape (nfreq, 3, npix).
         """
         freqs = check_freq_input(freqs)
+        weights = utils.normalize_weights(freqs, weights)
         outputs = (
             compute_spdust_emission_numba(
                 freqs.value,
+                weights,
                 self.I_ref.value,
                 self.freq_ref_I.value,
                 self.freq_peak.value,
@@ -107,11 +109,15 @@ def compute_spdust_scaling_numba(freq, freq_ref_I, freq_peak, emissivity):
 
 
 @njit(parallel=True)
-def compute_spdust_emission_numba(freqs, I_ref, freq_ref_I, freq_peak, emissivity):
-    outputs = np.empty((len(freqs), 1, len(I_ref)), dtype=I_ref.dtype)
-    for i_freq, freq in enumerate(freqs):
-        outputs[i_freq, 0] = I_ref * compute_spdust_scaling_numba(
-            freq, freq_ref_I, freq_peak, emissivity
+def compute_spdust_emission_numba(
+    freqs, weights, I_ref, freq_ref_I, freq_peak, emissivity
+):
+    outputs = np.zeros((3, len(I_ref)), dtype=I_ref.dtype)
+    for freq, weight in zip(freqs, weights):
+        outputs[0] += (
+            weight
+            * I_ref
+            * compute_spdust_scaling_numba(freq, freq_ref_I, freq_peak, emissivity)
         )
     return outputs
 
@@ -131,8 +137,7 @@ class SpDustPol(SpDust):
         angle_U,
         nside,
         unit_I=None,
-        pixel_indices=None,
-        mpi_comm=None,
+        map_dist=None,
     ):
         super().__init__(
             map_I=map_I,
@@ -142,14 +147,13 @@ class SpDustPol(SpDust):
             freq_ref_peak=freq_ref_peak,
             nside=nside,
             unit_I=unit_I,
-            pixel_indices=pixel_indices,
-            mpi_comm=mpi_comm,
+            map_dist=map_dist,
         )
         self.pol_angle = np.arctan2(self.read_map(angle_U), self.read_map(angle_Q))
         self.pol_frac = pol_frac
 
     @u.quantity_input
-    def get_emission(self, freqs: u.GHz):
+    def get_emission(self, freqs: u.GHz, weights=None):
         """ This function evaluates the component model at a either
         a single frequency, an array of frequencies, or over a bandpass.
 
@@ -166,9 +170,11 @@ class SpDustPol(SpDust):
             shape (nfreq, 3, npix).
         """
         freqs = check_freq_input(freqs)
+        weights = utils.normalize_weights(freqs, weights)
         outputs = (
             compute_spdust_emission_pol_numba(
                 freqs.value,
+                weights,
                 self.I_ref.value,
                 self.freq_ref_I.value,
                 self.freq_peak.value,
@@ -183,15 +189,16 @@ class SpDustPol(SpDust):
 
 @njit(parallel=True)
 def compute_spdust_emission_pol_numba(
-    freqs, I_ref, freq_ref_I, freq_peak, emissivity, pol_angle, pol_frac
+    freqs, weights, I_ref, freq_ref_I, freq_peak, emissivity, pol_angle, pol_frac
 ):
-    outputs = np.empty((len(freqs), 3, len(I_ref)), dtype=I_ref.dtype)
+    output = np.zeros((3, len(I_ref)), dtype=I_ref.dtype)
     I, Q, U = 0, 1, 2
-    for i_freq, freq in enumerate(freqs):
-        outputs[i_freq, I] = I_ref
-        outputs[i_freq, Q] = I_ref * pol_frac * np.cos(pol_angle)
-        outputs[i_freq, U] = I_ref * pol_frac * np.sin(pol_angle)
-        outputs[i_freq, :] *= compute_spdust_scaling_numba(
-            freq, freq_ref_I, freq_peak, emissivity
+    for freq, weight in zip(freqs, weights):
+        scaling = (
+            compute_spdust_scaling_numba(freq, freq_ref_I, freq_peak, emissivity)
+            * weight
         )
-    return outputs
+        output[I] += scaling * I_ref
+        output[Q] += scaling * I_ref * pol_frac * np.cos(pol_angle)
+        output[U] += scaling * I_ref * pol_frac * np.sin(pol_angle)
+    return output

--- a/pysm/models/spdust.py
+++ b/pysm/models/spdust.py
@@ -193,12 +193,13 @@ def compute_spdust_emission_pol_numba(
 ):
     output = np.zeros((3, len(I_ref)), dtype=I_ref.dtype)
     I, Q, U = 0, 1, 2
-    for freq, weight in zip(freqs, weights):
-        scaling = (
-            compute_spdust_scaling_numba(freq, freq_ref_I, freq_peak, emissivity)
-            * weight
+    for i, (freq, weight) in enumerate(zip(freqs, weights)):
+        scaling = compute_spdust_scaling_numba(freq, freq_ref_I, freq_peak, emissivity)
+        utils.trapz_step_inplace(freqs, weights, i, scaling * I_ref, output[I])
+        utils.trapz_step_inplace(
+            freqs, weights, i, scaling * I_ref * pol_frac * np.cos(pol_angle), output[Q]
         )
-        output[I] += scaling * I_ref
-        output[Q] += scaling * I_ref * pol_frac * np.cos(pol_angle)
-        output[U] += scaling * I_ref * pol_frac * np.sin(pol_angle)
+        utils.trapz_step_inplace(
+            freqs, weights, i, scaling * I_ref * pol_frac * np.sin(pol_angle), output[U]
+        )
     return output

--- a/pysm/models/template.py
+++ b/pysm/models/template.py
@@ -107,6 +107,8 @@ def apply_smoothing_and_coord_transform(
     else:
         smoothed_map = mpi_smoothing(input_map, fwhm, map_dist)
 
+    if hasattr(input_map, "unit"):
+        smoothed_map <<= input_map.unit
     return smoothed_map
 
 

--- a/pysm/models/template.py
+++ b/pysm/models/template.py
@@ -63,35 +63,6 @@ class Model:
         mpi_comm = None if self.map_dist is None else self.map_dist.mpi_comm
         return read_txt(path, mpi_comm=mpi_comm, **kwargs)
 
-    def apply_bandpass(self, bpasses):
-        """ Method to calculate the emission averaged over a bandpass.
-
-        Note: this method may be overridden by child classes which require more
-        complicated implementations of bandpass integration, as long as they are
-        compatible with the input and output of this template.
-
-        Parameters
-        ----------
-        bandpass: list(dict)
-            List of dictionaries. Each dictionary contains 'freqs' and 'weights'
-            which give the range of frequencies over which the bandpass is
-            sensitive, and the correpsonding weight.
-
-        Returns
-        -------
-        list(dict)
-            The same list of dictionaries, updated with a 'response' keyword,
-            containing the sky response to this bandpass.
-        """
-        out = []
-        for (freqs, weights) in bpasses:
-            freqs, weights = apply_normalization(freqs, weights)
-            weight_emission = self.get_emission(freqs) * weights[:, None, None]
-            # NOTE THIS CURRENTLY ASSUMES THAT THE BANDPASS IS GIVEN IN UNITS OF
-            # UKRJ. THIS SHOULD BE MADE EXPLICIT.
-            out.append(np.trapz(weight_emission, freqs, axis=0))
-        return np.array(out)
-
 
 def apply_smoothing_and_coord_transform(
     input_map, fwhm=None, coord="G", lmax=None, map_dist=None

--- a/pysm/models/template.py
+++ b/pysm/models/template.py
@@ -94,7 +94,7 @@ def apply_smoothing_and_coord_transform(
 
     if map_dist is None:
         nside = hp.get_nside(input_map)
-        alm = hp.map2alm(input_map, lmax=lmax, use_pixel_weights=True, iter=1)
+        alm = hp.map2alm(input_map, lmax=lmax, use_pixel_weights=True if nside > 16 else False, iter=1)
         if fwhm is not None:
             hp.smoothalm(
                 alm, fwhm=fwhm.to_value(u.rad), verbose=False, inplace=True, pol=True

--- a/pysm/models/template.py
+++ b/pysm/models/template.py
@@ -36,7 +36,7 @@ class Model:
     If libsharp is not available, pixels are distributed uniformly across
     processes, see :py:func:`pysm.mpi.distribute_pixels_uniformly`"""
 
-    def __init__(self, nside, smoothing_lmax=None, pixel_indices=None, mpi_comm=None):
+    def __init__(self, nside, map_dist=None):
         """
         Parameters
         ----------
@@ -49,37 +49,19 @@ class Model:
         """
         self.nside = nside
         assert nside is not None
-        self.mpi_comm = mpi_comm
-        self.smoothing_lmax = (
-            (3 * self.nside - 1) if smoothing_lmax is None else smoothing_lmax
-        )
-
-        self.pixel_indices = pixel_indices
-        if self.mpi_comm is not None and pixel_indices is None:
-            if mpi.libsharp is None:
-                self.pixel_indices = mpi.distribute_pixels_uniformly(
-                    self.mpi_comm, self.nside
-                )
-            else:
-                self.pixel_indices, self.libsharp_grid, self.libsharp_order = mpi.distribute_rings_libsharp(
-                    self.mpi_comm, self.nside, lmax=self.smoothing_lmax
-                )
+        self.map_dist = map_dist
 
     def read_map(self, path, unit=None, field=0):
         """Wrapper of the PySM read_map function that automatically
         uses nside, pixel_indices and mpi_comm defined in this Model
         """
         return read_map(
-            path,
-            self.nside,
-            unit=unit,
-            field=field,
-            pixel_indices=self.pixel_indices,
-            mpi_comm=self.mpi_comm,
+            path, self.nside, unit=unit, field=field, map_dist=self.map_dist
         )
 
     def read_txt(self, path, **kwargs):
-        return read_txt(path, mpi_comm=self.mpi_comm, **kwargs)
+        mpi_comm = None if self.map_dist is None else self.map_dist.mpi_comm
+        return read_txt(path, mpi_comm=mpi_comm, **kwargs)
 
     def apply_bandpass(self, bpasses):
         """ Method to calculate the emission averaged over a bandpass.
@@ -110,7 +92,10 @@ class Model:
             out.append(np.trapz(weight_emission, freqs, axis=0))
         return np.array(out)
 
-def apply_smoothing(skies, fwhms, coord="G", lmax=None, mpi_comm=None):
+
+def apply_smoothing_and_coord_transform(
+    input_map, fwhm=None, coord="G", lmax=None, map_dist=None
+):
     """ Method to apply smoothing to a set of simulations. This currently
     applies only the `healpy.smoothing` Gaussian smoothing kernel, but will
     be updated with a more general functionality.
@@ -136,96 +121,74 @@ def apply_smoothing(skies, fwhms, coord="G", lmax=None, mpi_comm=None):
         Array containing the smoothed skies.
     """
 
-    if isinstance(fwhms, list):
-        fwhms = np.array(fwhms) * u.arcmin
-    elif isinstance(fwhms, np.ndarray):
-        fwhms *= u.arcmin
-    else:
-        fwhms = np.array([fwhms]) * u.arcmin
-        try:
-            assert fwhms.ndim < 2
-        except AssertionError:
-            print(
-                """Check that FWHMs is given as a 1D list, 1D array.
-            of float"""
-            )
-
-    nside = hp.get_nside(skies[0])
-    out = []
-    for sky, fwhm in zip(skies, fwhms):
-        if mpi_comm is None:
-            alm = hp.map2alm(
-                sky, lmax=lmax, use_pixel_weights=True, iter=1
-            )
+    if map_dist is None:
+        nside = hp.get_nside(input_map)
+        alm = hp.map2alm(input_map, lmax=lmax, use_pixel_weights=True, iter=1)
+        if fwhm is not None:
             hp.smoothalm(
-                alm,
-                fwhm=fwhm.to_value(u.rad),
-                verbose=False,
-                inplace=True,
-                pol=True,
+                alm, fwhm=fwhm.to_value(u.rad), verbose=False, inplace=True, pol=True
             )
-            if coord != "G":
-                rot = hp.Rotator(coord=["G", coord])
-                rot.rotate_alm(alm, inplace=True)
-            smoothed_sky = hp.alm2map(
-                alm, nside=nside, verbose=False, pixwin=False
-            )
+        if coord != "G":
+            rot = hp.Rotator(coord=["G", coord])
+            rot.rotate_alm(alm, inplace=True)
+        smoothed_map = hp.alm2map(alm, nside=nside, verbose=False, pixwin=False)
 
-        else:
-            smoothed_sky = mpi_smoothing(sky)
-        out.append(smoothed_sky)
-    return np.array(out)
+    else:
+        smoothed_map = mpi_smoothing(input_map, fwhm, map_dist)
 
-def mpi_smoothing(self, sky, fwhm):
+    return smoothed_map
+
+
+def mpi_smoothing(input_map, fwhm, map_dist):
     import libsharp
 
     beam = hp.gauss_beam(
-        fwhm=fwhm.to(u.rad).value, lmax=self.smoothing_lmax, pol=True
+        fwhm=fwhm.to(u.rad).value, lmax=map_dist.smoothing_lmax, pol=True
     )
 
-    sky_I = sky if sky.ndim == 1 else sky[0]
-    sky_I_contig = np.ascontiguousarray(sky_I.reshape((1, 1, -1))).astype(
+    input_map_I = input_map if input_map.ndim == 1 else input_map[0]
+    input_map_I_contig = np.ascontiguousarray(input_map_I.reshape((1, 1, -1))).astype(
         np.float64, copy=False
     )
 
     alm_sharp_I = libsharp.analysis(
-        self.libsharp_grid,
-        self.libsharp_order,
-        sky_I_contig,
+        map_dist.libsharp_grid,
+        map_dist.libsharp_order,
+        input_map_I_contig,
         spin=0,
-        comm=self.mpi_comm,
+        comm=map_dist.mpi_comm,
     )
-    self.libsharp_order.almxfl(alm_sharp_I, np.ascontiguousarray(beam[:, 0:1]))
+    map_dist.libsharp_order.almxfl(alm_sharp_I, np.ascontiguousarray(beam[:, 0:1]))
     out = libsharp.synthesis(
-        self.libsharp_grid,
-        self.libsharp_order,
+        map_dist.libsharp_grid,
+        map_dist.libsharp_order,
         alm_sharp_I,
         spin=0,
-        comm=self.mpi_comm,
+        comm=map_dist.mpi_comm,
     )[0]
     assert np.isnan(out).sum() == 0
 
-    if utils.has_polarization(sky):
+    if utils.has_polarization(input_map):
         alm_sharp_P = libsharp.analysis(
-            self.libsharp_grid,
-            self.libsharp_order,
-            np.ascontiguousarray(sky[1:3, :].reshape((1, 2, -1))).astype(
+            map_dist.libsharp_grid,
+            map_dist.libsharp_order,
+            np.ascontiguousarray(input_map[1:3, :].reshape((1, 2, -1))).astype(
                 np.float64, copy=False
             ),
             spin=2,
-            comm=self.mpi_comm,
+            comm=map_dist.mpi_comm,
         )
 
-        self.libsharp_order.almxfl(
+        map_dist.libsharp_order.almxfl(
             alm_sharp_P, np.ascontiguousarray(beam[:, (1, 2)])
         )
 
         signal_map_P = libsharp.synthesis(
-            self.libsharp_grid,
-            self.libsharp_order,
+            map_dist.libsharp_grid,
+            map_dist.libsharp_order,
             alm_sharp_P,
             spin=2,
-            comm=self.mpi_comm,
+            comm=map_dist.mpi_comm,
         )[0]
         out = np.vstack((out, signal_map_P))
     return out
@@ -309,15 +272,7 @@ def extract_hdu_unit(path):
     return unit
 
 
-def read_map(
-    path,
-    nside,
-    unit=None,
-    field=0,
-    pixel_indices=None,
-    mpi_comm=None,
-    distribute_rings_libsharp=None,
-):
+def read_map(path, nside, unit=None, field=0, map_dist=None):
     """Wrapper of `healpy.read_map` for PySM data. This function also extracts
     the units from the fits HDU and applies them to the data array to form an
     `astropy.units.Quantity` object.
@@ -337,6 +292,8 @@ def read_map(
     map : ndarray
         Numpy array containing HEALPix map in RING ordering.
     """
+    mpi_comm = None if map_dist is None else map_dist.mpi_comm
+    pixel_indices = None if map_dist is None else map_dist.pixel_indices
     # read map. Add `str()` operator in case dealing with `Path` object.
     if os.path.exists(str(path)):  # Python 3.5 requires turning a Path object to str
         filename = str(path)
@@ -379,7 +336,7 @@ def read_map(
         dtype = mpi_comm.bcast(dtype, root=0)
         if mpi_comm.rank > 0:
             output_map = np.empty(shape, dtype=dtype)
-        mpi_comm.Bcast(output_map.astype(np.float32), root=0)
+        mpi_comm.Bcast(output_map, root=0)
         unit = mpi_comm.bcast(unit, root=0)
 
     if pixel_indices is not None:

--- a/pysm/models/template.py
+++ b/pysm/models/template.py
@@ -94,7 +94,7 @@ def apply_smoothing_and_coord_transform(
 
     if map_dist is None:
         nside = hp.get_nside(input_map)
-        alm = hp.map2alm(input_map, lmax=lmax, use_pixel_weights=True if nside > 16 else False, iter=1)
+        alm = hp.map2alm(input_map, lmax=lmax, use_pixel_weights=True if nside > 16 else False)
         if fwhm is not None:
             hp.smoothalm(
                 alm, fwhm=fwhm.to_value(u.rad), verbose=False, inplace=True, pol=True

--- a/pysm/tests/test_ame.py
+++ b/pysm/tests/test_ame.py
@@ -16,8 +16,10 @@ def test_model(model, freq):
         64,
         unit=pysm.units.uK_RJ,
         field=0,
-    ).reshape((1, 1, -1))
-
-    assert_quantity_allclose(
-        expected_map, model.get_emission(freq << pysm.units.GHz), rtol=1e-5
     )
+
+    emission = model.get_emission(freq << pysm.units.GHz)
+    assert_quantity_allclose(expected_map, emission[0], rtol=1e-5)
+
+    for i in [1, 2]:
+        assert_quantity_allclose(0 * pysm.units.uK_RJ, emission[i])

--- a/pysm/tests/test_ame2.py
+++ b/pysm/tests/test_ame2.py
@@ -16,7 +16,7 @@ def test_model(model, freq):
         64,
         unit=pysm.units.uK_RJ,
         field=(0, 1, 2),
-    ).reshape((1, 3, -1))
+    )
 
     assert_quantity_allclose(
         expected_map, model.get_emission(freq << pysm.units.GHz), rtol=1e-3

--- a/pysm/tests/test_dust.py
+++ b/pysm/tests/test_dust.py
@@ -29,7 +29,7 @@ def test_dust_model(model_tag, freq):
         64,
         unit="uK_RJ",
         field=(0, 1, 2),
-    ).reshape((1, 3, -1))
+    )
 
     assert_quantity_allclose(
         expected_output, model.get_emission(freq * units.GHz), rtol=1e-5

--- a/pysm/tests/test_freefree.py
+++ b/pysm/tests/test_freefree.py
@@ -16,8 +16,8 @@ def test_model(model, freq):
         64,
         unit=pysm.units.uK_RJ,
         field=0,
-    ).reshape((1, 1, -1))
+    )
 
     assert_quantity_allclose(
-        expected_map, model.get_emission(freq << pysm.units.GHz), rtol=1e-5
+        expected_map, model.get_emission(freq << pysm.units.GHz)[0], rtol=1e-5
     )

--- a/pysm/tests/test_interpolating.py
+++ b/pysm/tests/test_interpolating.py
@@ -17,4 +17,4 @@ def test_interpolating(tmp_path):
     )
 
     interpolated_map = interp.get_emission(15 * u.GHz)
-    np.testing.assert_allclose(0.5 * np.ones((1,) + shape)*u.uK_RJ, interpolated_map)
+    np.testing.assert_allclose(0.5 * np.ones(shape)*u.uK_RJ, interpolated_map)

--- a/pysm/tests/test_read_map_mpi.py
+++ b/pysm/tests/test_read_map_mpi.py
@@ -19,26 +19,20 @@ def test_read_map_mpi_pixel_indices(mpi_comm):
     # Reads pixel [0] on rank 0
     # pixels [0,1] on rank 1
     # pixels [0,1,2] on rank 2 and so on.
-    m = pysm.read_map(
-        "pysm_2/dust_temp.fits",
-        nside=8,
-        field=0,
-        pixel_indices=list(range(0, mpi_comm.rank + 1)),
-        mpi_comm=mpi_comm,
+    map_dist = pysm.MapDistribution(
+        mpi_comm=mpi_comm, pixel_indices=list(range(0, mpi_comm.rank + 1))
     )
+    m = pysm.read_map("pysm_2/dust_temp.fits", nside=8, field=0, map_dist=map_dist)
     assert len(m) == mpi_comm.rank + 1
 
 
 def test_read_map_mpi_uniform_distribution(mpi_comm):
     # Spreads the map equally across processes
-    pixel_indices = pysm.mpi.distribute_pixels_uniformly(mpi_comm, nside=8)
-    m = pysm.read_map(
-        "pysm_2/dust_temp.fits",
-        nside=8,
-        field=0,
-        pixel_indices=pixel_indices,
+    map_dist = pysm.MapDistribution(
         mpi_comm=mpi_comm,
+        pixel_indices=pysm.mpi.distribute_pixels_uniformly(mpi_comm, nside=8),
     )
+    m = pysm.read_map("pysm_2/dust_temp.fits", nside=8, field=0, map_dist=map_dist)
     npix = hp.nside2npix(8)
     assert (
         npix % mpi_comm.size == 0

--- a/pysm/tests/test_synchrotron.py
+++ b/pysm/tests/test_synchrotron.py
@@ -17,7 +17,7 @@ def test_synchrotron_model(model, freq):
         64,
         unit=pysm.units.uK_RJ,
         field=(0, 1, 2),
-    ).reshape((1, 3, -1))
+    )
 
     assert_quantity_allclose(
         synch, synchrotron.get_emission(freq << pysm.units.GHz), rtol=1e-5

--- a/pysm/utils/__init__.py
+++ b/pysm/utils/__init__.py
@@ -24,3 +24,9 @@ def has_polarization(m):
         return len(m[0]) == 3
     else:
         raise TypeError("Map format not understood")
+
+
+def normalize_weights(freqs, weights):
+    if weights is None:
+        weights = np.ones(len(freqs), dtype=np.float)
+    return weights / weights.sum()

--- a/pysm/utils/__init__.py
+++ b/pysm/utils/__init__.py
@@ -4,6 +4,7 @@
 # functions.
 
 import numpy as np
+from numba import njit
 
 from .exceptions import IllegalArgumentError
 
@@ -27,6 +28,36 @@ def has_polarization(m):
 
 
 def normalize_weights(freqs, weights):
-    if weights is None:
-        weights = np.ones(len(freqs), dtype=np.float)
-    return weights / weights.sum()
+    if freqs.isscalar or len(freqs) == 1:
+        return np.array([1.0])
+    else:
+        if weights is None:
+            weights = np.ones(len(freqs), dtype=np.float)
+        return weights / np.trapz(weights, freqs.value)
+
+
+@njit
+def trapz_step_inplace(freqs, weights, i, m, output):
+    """Execute a step of the trapezoidal rule and accumulate into output
+
+    freqs : ndarray
+        Frequency axis, generally in GHz, but doesn't matter as long as
+        weights were normalized accordingly
+    weights : ndarray
+        Frequency bandpass response, normalized to unit integral (with trapz)
+    i : integer
+        Index of the current step in the arrays
+    m : ndarray
+        Emission evaluated at the current frequency to be accumulated
+    output : ndarray
+        Array where the integrated emission is accumulated.
+    """
+    if i == 0 and len(freqs) == 1:
+        delta_freq = 0.5
+    elif i == 0:
+        delta_freq = freqs[1] - freqs[0]
+    elif i == (len(freqs) - 1):
+        delta_freq = freqs[-1] - freqs[-2]
+    else:
+        delta_freq = freqs[i + 1] - freqs[i - 1]
+    output += 0.5 * m * weights[i] * delta_freq

--- a/pysm/utils/__init__.py
+++ b/pysm/utils/__init__.py
@@ -52,12 +52,16 @@ def trapz_step_inplace(freqs, weights, i, m, output):
     output : ndarray
         Array where the integrated emission is accumulated.
     """
+    # case for a single frequency, compensate for the .5 factor
     if i == 0 and len(freqs) == 1:
-        delta_freq = 0.5
+        delta_freq = 2
+    # first step of the integration
     elif i == 0:
         delta_freq = freqs[1] - freqs[0]
+    # last step
     elif i == (len(freqs) - 1):
         delta_freq = freqs[-1] - freqs[-2]
+    # middle steps
     else:
         delta_freq = freqs[i + 1] - freqs[i - 1]
     output += 0.5 * m * weights[i] * delta_freq


### PR DESCRIPTION
@bthorne93 I've implemented bandpass integration at `numba` level, so now we are looping and accumulating into 1 single map instead of creating first 1 map per frequency and then integrate.

then I've debugged and tested all the standard models with MPI.

I haven't implemented `Instrument` yet, I think it is nice to have a standalone smoothing without the need of defining an instrument.

In order to group-up the metadata relative to MPI, I've created a new `MapDistribution` object, good news is that user not using MPI don't need to use it at all.
Here an example of the current API with MPI:

```python

import numpy as np
import pysm
import pysm.units as u

from mpi4py import MPI

nside = 32

map_dist = pysm.MapDistribution(
    pixel_indices=None, nside=nside, mpi_comm=MPI.COMM_WORLD
)

sky = pysm.Sky(nside=nside, preset_strings=["d1", "s1", "f1", "a1"], map_dist=map_dist)

m = sky.get_emission(
    freq=np.arange(50, 55) * u.GHz, weights=np.array([0.1, 0.3, 0.5, 0.3, 0.1])
)[0]

print(map_dist.mpi_comm.rank, m.shape, m.min(), m.max())

m_smoothed = pysm.apply_smoothing_and_coord_transform(
    m, fwhm=1 * u.deg, map_dist=map_dist
)

print(map_dist.mpi_comm.rank, m_smoothed.shape, m_smoothed.min(), m_smoothed.max())
```

Please let me know if you have any suggestions on the interface!