### PR TITLE
MPI node shared memory

### DIFF
--- a/mpi_examples/pysm3_mpi_so_pysm_models.py
+++ b/mpi_examples/pysm3_mpi_so_pysm_models.py
@@ -16,6 +16,11 @@ map_dist = pysm.MapDistribution(
     pixel_indices=None, nside=nside, mpi_comm=MPI.COMM_WORLD
 )
 
+import warnings
+if map_dist.mpi_comm.rank > 0:
+    warnings.filterwarnings("ignore")
+
+
 memreport = MemReporter(map_dist.mpi_comm)
 memreport.run("After imports")
 

--- a/mpi_examples/pysm3_mpi_so_pysm_models.py
+++ b/mpi_examples/pysm3_mpi_so_pysm_models.py
@@ -25,7 +25,7 @@ memreport = MemReporter(map_dist.mpi_comm)
 memreport.run("After imports")
 
 components = []
-for comp in ["SO_d0", "SO_s0", "SO_f0", "SO_a0"]:
+for comp in ["SO_d0s", "SO_s0s", "SO_f0s", "SO_a0s"]:
     components.append(get_so_models(comp, nside, map_dist=map_dist))
 
 components.append(

--- a/pysm/models/template.py
+++ b/pysm/models/template.py
@@ -254,10 +254,7 @@ def read_map(path, nside, unit=None, field=0, map_dist=None, dataurl=None):
         rank_comm = mpi_comm.Split(node_comm.rank, my_node)
         if mpi_comm.rank == 0:
             node_shared_map[:] = output_map
-            print(output_map[:3])
         rank_comm.Bcast(node_shared_map, root=from_node)
-        mpi_comm.barrier()
-        print("rank", mpi_comm.rank, node_shared_map[:3])
 
         # code with broadcast to whole communicator
         # if mpi_comm.rank > 0:

--- a/pysm/models/template.py
+++ b/pysm/models/template.py
@@ -261,15 +261,15 @@ def read_map(path, nside, unit=None, field=0, map_dist=None, dataurl=None):
         # if mpi_comm.rank > 0:
         #     output_map = np.empty(shape, dtype=dtype)
         # mpi_comm.Bcast(output_map, root=0)
-
-        sys.exit(0)
+    else: # without MPI node_shared_map is just another reference to output_map
+        node_shared_map = output_map
 
     if pixel_indices is not None:
         # make copies so that Python can release the full array
         try:  # multiple components
-            output_map = np.array([each[pixel_indices].copy() for each in output_map])
+            output_map = np.array([each[pixel_indices].copy() for each in node_shared_map])
         except IndexError:  # single component
-            output_map = output_map[pixel_indices].copy()
+            output_map = node_shared_map[pixel_indices].copy()
 
     return u.Quantity(output_map, unit, copy=False)
 

--- a/pysm/models/template.py
+++ b/pysm/models/template.py
@@ -7,7 +7,6 @@ this template, ensuring that the new subclass has the required
 Objects:
     Model
 """
-import sys
 import warnings
 import os.path
 import numpy as np

--- a/pysm/tests/test_read_map_mpi.py
+++ b/pysm/tests/test_read_map_mpi.py
@@ -39,7 +39,14 @@ def test_read_map_mpi_uniform_distribution(mpi_comm):
     ), "This test requires the size of the communicator to divide the number of pixels {}".format(
         npix
     )
-    assert len(m) == npix / mpi_comm.size
+    num_local_pix = len(m)
+    assert num_local_pix == npix / mpi_comm.size
+
+    complete_m = pysm.read_map("pysm_2/dust_temp.fits", nside=8, field=0)
+    np.testing.assert_allclose(
+        m,
+        complete_m[num_local_pix * mpi_comm.rank : num_local_pix * (mpi_comm.rank + 1)],
+    )
 
 
 def test_distribute_rings_libsharp(mpi_comm):


### PR DESCRIPTION
working to reduce memory usage in MPI jobs, see https://github.com/healpy/pysm/issues/30

Currently we read all input maps on MPI rank 0 from disk, then broadcast each of them to all MPI processes. A node could have up to 16 MPI processes for software that scales poorly with threads.
So we could have 16 copies of a map in a single node.

We want instead to allocate a node-shared buffer with MPI, then read the map on rank 0 of MPI Comm world and then have 1 proc per node receive the map and copy to the node-shared buffer. So we have just 1 map per node.