### PR TITLE
Add missing requirements (healpy, numba and toml)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,16 +30,16 @@ exclude = extern,sphinx,*parsetab.py
 [metadata]
 package_name = pysm
 description = Python Sky Model for Microwave and Submm experiments
-long_description = 
+long_description =
 author = Ben Thorne, David Alonso, Sigurd Naess, Jo Dunkley, Andrea Zonca
-author_email = 
+author_email =
 license = BSD 3-Clause
 url = https://github.com/healpy/pysm
 edit_on_github = True
 github_project = healpy/pysm
 # install_requires should be formatted as a comma-separated list, e.g.:
 # install_requires = astropy, scipy, matplotlib
-install_requires = astropy
+install_requires = astropy, healpy, numba, toml
 # version should be PEP440 compatible (https://www.python.org/dev/peps/pep-0440/)
 version = 3.1.dev
 # Note: you will also need to change this in your package's __init__.py
@@ -48,4 +48,3 @@ minimum_python_version = 3.5
 [entry_points]
 
 # astropy-package-template-example = packagename.example_mod:main
-


### PR DESCRIPTION
Starting from scratch within a fresh virtual env., the installation *via* `pip install` works fine but executing the following snippet
```python
import pysm
sky = pysm.Sky(nside=64, preset_strings=['d1'])
print(sky.get_emission(12*pysm.units.GHz)[:5])
```
raises errors due to missing `healpy`package then `numba` and finally `toml`. This PR updates the requirement list and should fix the issue.